### PR TITLE
Add link to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 readme = "README.md"
 authors = ["Michael Dunsmuir <mjdunsmuir@gmail.com>"]
 homepage = "https://github.com/mdunsmuir/copy_dir"
+repository = "https://github.com/mdunsmuir/copy_dir"
 documentation = "https://docs.rs/copy_dir"
 include = [
     "**/*.rs",


### PR DESCRIPTION
Thank you very much for publishing this crate exactly fits my current use case.

Having the link to the repository in "repository" instead of only homepage makes it easier for others to find the repo. It's also recommended by https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate