### PR TITLE
port tests from tempdir to tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ include = [
 walkdir = "2"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
 
-    extern crate tempdir;
+    extern crate tempfile;
     extern crate walkdir;
 
     #[test]
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn source_does_not_exist() {
-        let base_dir = tempdir::TempDir::new("copy_dir_test").unwrap();
+        let base_dir = tempfile::TempDir::with_prefix("copy_dir_test").unwrap();
         let source_path = base_dir.as_ref().join("noexist.file");
         match super::copy_dir(&source_path, "dest.file") {
             Ok(_) => panic!("expected Err"),
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn target_exists() {
-        let base_dir = tempdir::TempDir::new("copy_dir_test").unwrap();
+        let base_dir = tempfile::TempDir::with_prefix("copy_dir_test").unwrap();
         let source_path = base_dir.as_ref().join("exist.file");
         let target_path = base_dir.as_ref().join("exist2.file");
 
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     fn attempt_copy_under_self() {
-        let base_dir = tempdir::TempDir::new("copy_dir_test").unwrap();
+        let base_dir = tempfile::TempDir::with_prefix("copy_dir_test").unwrap();
         let dir = Dir(
             "foo",
             vec![File("bar"), Dir("baz", vec![File("quux"), File("fobe")])],
@@ -300,7 +300,7 @@ mod tests {
         explicit_name: bool,
         o_pre_state: Option<&DirMaker>,
     ) {
-        let base_dir = tempdir::TempDir::new("copy_dir_test").unwrap();
+        let base_dir = tempfile::TempDir::with_prefix("copy_dir_test").unwrap();
 
         let source_dir = base_dir.as_ref().join("source");
         let our_dir = base_dir.as_ref().join("ours");
@@ -346,7 +346,7 @@ mod tests {
     fn dir_maker_and_assert_dirs_same_baseline() {
         let dir = Dir("foobar", vec![File("bar"), Dir("baz", Vec::new())]);
 
-        let base_dir = tempdir::TempDir::new("copy_dir_test").unwrap();
+        let base_dir = tempfile::TempDir::with_prefix("copy_dir_test").unwrap();
 
         let a_path = base_dir.as_ref().join("a");
         let b_path = base_dir.as_ref().join("b");
@@ -367,7 +367,7 @@ mod tests {
 
         let dir2 = Dir("foobar", vec![File("fobe"), File("beez")]);
 
-        let base_dir = tempdir::TempDir::new("copy_dir_test").unwrap();
+        let base_dir = tempfile::TempDir::with_prefix("copy_dir_test").unwrap();
 
         let a_path = base_dir.as_ref().join("a");
         let b_path = base_dir.as_ref().join("b");


### PR DESCRIPTION
The tempdir crate is unmaintained, was last updated seven years ago, and pulls in really old versions of some of its dependencies.

The tempfile crate is actively maintained and replacing code usages is straightforward.

---

PS: I opened this against the "dependency-bump" branch which seems to contain the latest published code. Not sure why this hasn't been merged into the main branch ever.